### PR TITLE
Kimchi export configuration

### DIFF
--- a/kimchi/main.go
+++ b/kimchi/main.go
@@ -554,7 +554,7 @@ func saveKeys(cfg interface{}) (err error) {
 }
 
 func saveCfg(cfg interface{}) error {
-	fileName := fmt.Sprintf("%s.cfg", identifier(cfg))
+	fileName := fmt.Sprintf("%s.toml", identifier(cfg))
 	log.Printf("saveCfg of %s", fileName)
 	f, err := os.Create(fileName)
 	if err != nil {

--- a/kimchi/main.go
+++ b/kimchi/main.go
@@ -423,6 +423,7 @@ func main() {
 		log.Fatalf("Failed to launch authority: %v", err)
 	}
 	if *genOnly {
+		s.authConfig.Debug.GenerateOnly = false
 		if err := saveKeys(s.authConfig); err != nil {
 			log.Fatalf("%s", err)
 		}
@@ -441,6 +442,7 @@ func main() {
 			log.Fatalf("Failed to launch node: %v", err)
 		}
 		if *genOnly {
+			v.Debug.GenerateOnly = false
 			if err := saveKeys(v); err != nil {
 				log.Fatalf("%s", err)
 			}

--- a/kimchi/main.go
+++ b/kimchi/main.go
@@ -522,7 +522,7 @@ func normalizePaths(cfg interface{}) {
 		cfg.(*sConfig.Config).Server.DataDir = "/var/lib/katzenpost"
 		cfg.(*sConfig.Config).Management.Path = "/var/lib/katzenpost/management_sock"
 	case *aConfig.Config:
-		cfg.(*aConfig.Config).Authority.DataDir = "/var/lib/katzenpost"
+		cfg.(*aConfig.Config).Authority.DataDir = "/var/lib/katzenpost-authority"
 	}
 }
 


### PR DESCRIPTION
This PR adds a generateOnly (-g) option to kimchi, which will cause kimchi to write configuration files to disk for each of the nodes that it instantiated and then exit.

This is handy for people who want to experiment with running a mixnet.